### PR TITLE
feat: Implementar página de precios con CPT e integración WooCommerce

### DIFF
--- a/jacobo-theme/functions.php
+++ b/jacobo-theme/functions.php
@@ -195,6 +195,26 @@ function jacobo_theme_enqueue_theme_assets() {
         );
     }
 
+    // Enqueue script for pricing page only on its specific template page
+    if ( is_page_template('template-precios.php') ) {
+        wp_enqueue_script(
+            'jacobo-page-precios',
+            get_template_directory_uri() . '/js/page-precios.js',
+            array(), // No dependencies for this simple script
+            filemtime(get_template_directory() . '/js/page-precios.js'), // Versioning
+            true // Load in footer
+        );
+        wp_localize_script(
+            'jacobo-page-precios',      // El handle del script que acabas de encolar
+            'jacoboPreciosData',        // El nombre del objeto JavaScript que contendrá los datos
+            array(
+                'checkout_base_url' => home_url('/checkout/?add-to-cart='),
+                // Aquí podrías añadir otros datos si fueran necesarios en el futuro,
+                // por ejemplo, nonces si hicieras llamadas AJAX desde esta página.
+            )
+        );
+    }
+
     // Enqueue script for content calendar only on its specific template page
     if ( is_page_template('template-content-calendar.php') ) {
         wp_enqueue_script(
@@ -304,3 +324,78 @@ function jacobo_login_logo_url_title() {
     return get_bloginfo( 'name' );
 }
 add_filter( 'login_headertext', 'jacobo_login_logo_url_title' );
+
+// Registrar Custom Post Type para Planes de Precios
+function jacobo_register_plan_cpt() {
+
+    $labels = array(
+        'name'                  => _x( 'Planes', 'Post Type General Name', 'jacobo-theme' ),
+        'singular_name'         => _x( 'Plan', 'Post Type Singular Name', 'jacobo-theme' ),
+        'menu_name'             => __( 'Planes de Precios', 'jacobo-theme' ),
+        'name_admin_bar'        => __( 'Plan', 'jacobo-theme' ),
+        'archives'              => __( 'Archivo de Planes', 'jacobo-theme' ),
+        'attributes'            => __( 'Atributos del Plan', 'jacobo-theme' ),
+        'parent_item_colon'     => __( 'Plan Padre:', 'jacobo-theme' ),
+        'all_items'             => __( 'Todos los Planes', 'jacobo-theme' ),
+        'add_new_item'          => __( 'Añadir Nuevo Plan', 'jacobo-theme' ),
+        'add_new'               => __( 'Añadir Nuevo', 'jacobo-theme' ),
+        'new_item'              => __( 'Nuevo Plan', 'jacobo-theme' ),
+        'edit_item'             => __( 'Editar Plan', 'jacobo-theme' ),
+        'update_item'           => __( 'Actualizar Plan', 'jacobo-theme' ),
+        'view_item'             => __( 'Ver Plan', 'jacobo-theme' ),
+        'view_items'            => __( 'Ver Planes', 'jacobo-theme' ),
+        'search_items'          => __( 'Buscar Plan', 'jacobo-theme' ),
+        'not_found'             => __( 'No encontrado', 'jacobo-theme' ),
+        'not_found_in_trash'    => __( 'No encontrado en la papelera', 'jacobo-theme' ),
+        'featured_image'        => __( 'Imagen Destacada', 'jacobo-theme' ), // Aunque no la usemos ahora
+        'set_featured_image'    => __( 'Establecer imagen destacada', 'jacobo-theme' ),
+        'remove_featured_image' => __( 'Eliminar imagen destacada', 'jacobo-theme' ),
+        'use_featured_image'    => __( 'Usar como imagen destacada', 'jacobo-theme' ),
+        'insert_into_item'      => __( 'Insertar en el plan', 'jacobo-theme' ),
+        'uploaded_to_this_item' => __( 'Subido a este plan', 'jacobo-theme' ),
+        'items_list'            => __( 'Lista de planes', 'jacobo-theme' ),
+        'items_list_navigation' => __( 'Navegación de lista de planes', 'jacobo-theme' ),
+        'filter_items_list'     => __( 'Filtrar lista de planes', 'jacobo-theme' ),
+    );
+    $args = array(
+        'label'                 => __( 'Plan', 'jacobo-theme' ),
+        'description'           => __( 'Planes de suscripción para Jacobo', 'jacobo-theme' ),
+        'labels'                => $labels,
+        'supports'              => array( 'title', 'editor', 'custom-fields', 'page-attributes' ), // 'editor' para descripción, 'page-attributes' para 'plan_orden'
+        'hierarchical'          => false,
+        'public'                => true, // Hacerlo true para poder consultarlo con WP_Query y verlo individualmente si se desea
+        'show_ui'               => true,
+        'show_in_menu'          => true,
+        'menu_position'         => 5, // Debajo de "Entradas" o "Posts"
+        'menu_icon'             => 'dashicons-cart', // Icono de carrito
+        'show_in_admin_bar'     => true,
+        'show_in_nav_menus'     => true,
+        'can_export'            => true,
+        'has_archive'           => false, // No necesitamos una página de archivo para los planes por ahora
+        'exclude_from_search'   => true, // No incluir en búsquedas del sitio por defecto
+        'publicly_queryable'    => true, // Permitir consultas directas si es necesario
+        'capability_type'       => 'post', // O 'page' si se prefiere, 'post' es común para CPTs
+        'rewrite'               => array( 'slug' => 'planes-jacobo', 'with_front' => false ), // Slug para URLs amigables si se accede individualmente
+        'show_in_rest'          => true, // Habilitar para la API REST de WordPress
+    );
+    register_post_type( 'plan', $args );
+
+}
+add_action( 'init', 'jacobo_register_plan_cPT', 0 );
+
+// Flush rewrite rules on theme activation/deactivation or CPT registration for CPTs to work correctly
+// Esto es importante para que los permalinks del CPT funcionen inmediatamente después de la activación del tema.
+// Sin embargo, para desarrollo, a veces es más fácil ir a Ajustes > Enlaces Permanentes y guardar sin cambiar nada.
+function jacobo_theme_rewrite_flush() {
+    jacobo_register_plan_cpt(); // Asegurarse de que el CPT esté registrado
+    flush_rewrite_rules();
+}
+// Descomentar estas líneas temporalmente si los permalinks no funcionan tras añadir el CPT:
+// add_action( 'after_switch_theme', 'jacobo_theme_rewrite_flush' );
+// register_deactivation_hook( __FILE__, 'flush_rewrite_rules' ); // No usar __FILE__ aquí si el código está en functions.php, sino el path del plugin principal si fuera un plugin
+
+// Nota: Para `flush_rewrite_rules()` en un tema, es mejor hacerlo una vez.
+// Una forma común es guardando los Enlaces Permanentes en el admin de WP.
+// O en un hook de activación del tema. Para este ejercicio, el usuario puede simplemente
+// visitar Ajustes > Enlaces Permanentes en el admin de WP y hacer clic en "Guardar Cambios"
+// después de que este código se añada, para asegurar que los nuevos slugs de CPT funcionen.

--- a/jacobo-theme/js/page-precios.js
+++ b/jacobo-theme/js/page-precios.js
@@ -1,0 +1,127 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const billingToggle = document.getElementById('billingToggle');
+    const pricingPlansContainer = document.getElementById('pricingPlansContainer');
+
+    if (!billingToggle || !pricingPlansContainer) {
+        // console.warn('Toggle de facturación o contenedor de planes no encontrado.');
+        return;
+    }
+
+    // Función para formatear el precio (simple ejemplo, puedes hacerlo más robusto si necesitas)
+    function formatPrice(price) {
+        const priceNum = parseFloat(price);
+        if (isNaN(priceNum)) return price; // Devuelve original si no es número
+        return '$' + priceNum.toLocaleString('es-CL'); // Formato chileno
+    }
+
+    // Función para obtener el texto de ahorro (esto podría venir de un data-attribute también si varía por plan)
+    // Por ahora, usaremos el data-attribute 'plan_texto_ahorro_anual' que está en los metadatos del CPT
+    // y que debería ser pasado a un data-attribute en el HTML del plan si se quiere mostrar por plan.
+    // En el HTML actual, 'plan_texto_ahorro_anual' se obtiene pero no se imprime directamente en un data-attr visible
+    // para el ahorro global, sino que el span 'plan-ahorro-anual' está vacío.
+    // Vamos a asumir que queremos un texto de ahorro general o que el JS lo construye.
+    // Para esta versión, el span.plan-ahorro-anual es individual por plan.
+
+    function updatePricing() {
+        const isAnnual = billingToggle.checked;
+        const planColumns = pricingPlansContainer.querySelectorAll('.pricing-plan-column');
+
+        planColumns.forEach(plan => {
+            const priceElement = plan.querySelector('.plan-price');
+            const periodElement = plan.querySelector('.plan-period');
+            const ctaButton = plan.querySelector('.plan-cta-button');
+            const ahorroAnualElement = plan.querySelector('.plan-ahorro-anual');
+
+            if (!priceElement || !periodElement || !ctaButton || !ahorroAnualElement) {
+                // console.warn('Elementos del plan no encontrados en una columna:', plan);
+                return;
+            }
+
+            const precioMensual = priceElement.dataset.precioMensual;
+            const precioAnual = priceElement.dataset.precioAnual;
+            const idProductoMensual = ctaButton.dataset.idProductoMensual;
+            const idProductoAnual = ctaButton.dataset.idProductoAnual;
+
+            // Obtener el texto de ahorro específico del plan si existe (necesitarías añadirlo en template-precios.php)
+            // Ejemplo: <p class="plan-ahorro-anual" data-texto-ahorro="<?php echo esc_attr($texto_ahorro_anual); ?>"></p>
+            // Por ahora, si $texto_ahorro_anual se obtuvo en PHP, lo usaremos directamente desde allí
+            // pero no está en un data-attribute. El PHP lo tendría que imprimir en el span.
+            // Para que JS lo controle, el HTML debería tener el $texto_ahorro_anual en un data-attribute
+            // o el JS lo escribe directamente si el texto es fijo o se puede calcular.
+            // El span.plan-ahorro-anual está vacío en el PHP, lo que es bueno para que JS lo llene.
+            const textoAhorroAnual = priceElement.dataset.textoAhorroAnual || ''; // Asumimos que lo podríamos añadir aquí
+
+            const checkoutBaseUrl = jacoboPreciosData.checkout_base_url;
+
+
+            if (isAnnual) {
+                priceElement.textContent = formatPrice(precioAnual);
+                periodElement.textContent = '/año';
+                ctaButton.href = checkoutBaseUrl + idProductoAnual;
+                // Para el texto de ahorro, necesitaríamos el valor. Asumamos que lo tenemos en un data-attribute del plan
+                // o que el $texto_ahorro_anual del PHP se puede acceder/inferir.
+                // Si $texto_ahorro_anual se obtiene en el loop de PHP, lo ideal es pasarlo a un data-attribute:
+                // <p class="plan-ahorro-anual" data-ahorro-texto="<?php echo esc_attr($texto_ahorro_anual); ?>"></p>
+                // Y luego aquí: const textoAhorro = ahorroAnualElement.dataset.ahorroTexto || '';
+                // Por ahora, vamos a simular que si es anual, muestra el texto que se obtuvo del CPT
+                // (El PHP debería imprimir $texto_ahorro_anual en el span si no hay toggle, pero como hay toggle, JS lo controla)
+                // Para el ejemplo, si $texto_ahorro_anual está en un data-attribute del span:
+                ahorroAnualElement.textContent = priceElement.dataset.textoAhorroAnual || ''; // Si se añade data-texto-ahorro-anual al span del precio.
+                                                                                              // O si se crea un data-attribute específico en el elemento plan-ahorro-anual
+                                                                                              // ej. <p class="plan-ahorro-anual" data-texto-ahorro-propio="<?php echo esc_attr($texto_ahorro_anual); ?>"></p>
+                                                                                              // y leerlo con ahorroAnualElement.dataset.textoAhorroPropio
+                // Dado que el $texto_ahorro_anual ya se obtiene en el loop PHP, la forma más simple sería añadirlo
+                // al data-attribute del priceElement, como se hizo con los precios.
+                // En template-precios.php, en el span.plan-price, añadir:
+                // data-texto-ahorro-anual="<?php echo esc_attr($texto_ahorro_anual); ?>"
+                // Y aquí leerlo:
+                const textoAhorro = priceElement.dataset.textoAhorroAnual;
+                if(textoAhorro) {
+                    ahorroAnualElement.textContent = textoAhorro;
+                } else {
+                     // Calcular un ahorro genérico si no hay texto específico
+                    const ahorroCalculado = parseFloat(precioMensual) * 12 - parseFloat(precioAnual);
+                    if (ahorroCalculado > 0) {
+                        ahorroAnualElement.textContent = 'Ahorras ' + formatPrice(ahorroCalculado);
+                    } else {
+                        ahorroAnualElement.textContent = ''; // Sin ahorro o texto por defecto
+                    }
+                }
+
+
+            } else {
+                priceElement.textContent = formatPrice(precioMensual);
+                periodElement.textContent = '/mes';
+                ctaButton.href = checkoutBaseUrl + idProductoMensual;
+                ahorroAnualElement.textContent = ''; // Limpiar texto de ahorro
+            }
+        });
+    }
+
+    billingToggle.addEventListener('change', updatePricing);
+
+    // Inicializar precios al cargar la página
+    updatePricing();
+
+    // Pequeña mejora para el texto de ahorro general junto al toggle
+    const toggleAhorroHint = document.querySelector("label[for='billingToggle'] + span .text-cianElectrico");
+    if (toggleAhorroHint && pricingPlansContainer.querySelector('.pricing-plan-column')) {
+        // Tomar el primer plan para un ejemplo de ahorro
+        const primerPlanPriceElement = pricingPlansContainer.querySelector('.pricing-plan-column .plan-price');
+        if (primerPlanPriceElement) {
+            const precioMensual = parseFloat(primerPlanPriceElement.dataset.precioMensual);
+            const precioAnual = parseFloat(primerPlanPriceElement.dataset.precioAnual);
+            if (precioMensual && precioAnual && (precioMensual * 12 > precioAnual) ) {
+                const porcentajeAhorro = Math.round(((precioMensual * 12 - precioAnual) / (precioMensual * 12)) * 100);
+                if (porcentajeAhorro > 0) {
+                     toggleAhorroHint.textContent = `(Ahorra hasta ${porcentajeAhorro}%)`;
+                } else {
+                    toggleAhorroHint.textContent = '(Planes Anuales Disponibles)';
+                }
+            } else {
+                 toggleAhorroHint.textContent = '(Planes Anuales Disponibles)';
+            }
+        }
+    }
+
+});

--- a/jacobo-theme/template-precios.php
+++ b/jacobo-theme/template-precios.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Template Name: Página de Precios
+ *
+ * Esta es la plantilla para mostrar los planes de precios de Jacobo.
+ */
+
+// Por ahora, solo la estructura básica. El contenido se añadirá en el siguiente paso.
+
+get_header();
+?>
+
+<main id="content" class="pt-16 md:pt-20 bg-azulNoche text-blancoPuro">
+    <div class="container mx-auto px-6 md:px-10 py-12 md:py-16">
+
+        <h1 class="font-sora text-4xl sm:text-5xl font-bold text-center mb-12"> <?php // Aumentado el mb aquí ?>
+            Elige el Plan Perfecto para
+            <span class="block sm:inline-block bg-clip-text text-transparent bg-gradient-to-r from-cianElectrico to-violetaNeon">
+                Impulsar tu Crecimiento
+            </span>
+        </h1>
+
+        <!-- Toggle Mensual/Anual -->
+        <div class="flex justify-center items-center space-x-3 mb-12 md:mb-16">
+            <span class="font-inter text-grisClaro">Mensual</span>
+            <label for="billingToggle" class="relative inline-flex items-center cursor-pointer">
+                <input type="checkbox" value="" id="billingToggle" class="sr-only peer">
+                <div class="w-14 h-7 bg-gray-700 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-blancoPuro after:content-[''] after:absolute after:top-1 after:left-1 after:bg-blancoPuro after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-gradient-to-r peer-checked:from-cianElectrico peer-checked:to-violetaNeon"></div>
+            </label>
+            <span class="font-inter text-grisClaro">
+                Anual <span class="text-xs text-cianElectrico font-semibold">(Ahorra!)</span> <?php // El texto de ahorro específico se mostrará por plan ?>
+            </span>
+        </div>
+
+        <!-- Contenedor de Planes -->
+        <div id="pricingPlansContainer" class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 xl:gap-10 items-stretch">
+            <?php
+            $args = array(
+                'post_type' => 'plan',
+                'posts_per_page' => -1,
+                'orderby' => 'menu_order', // Usar el campo 'Orden' de Atributos de Página
+                'order' => 'ASC'
+            );
+            $planes_query = new WP_Query( $args );
+
+            if ( $planes_query->have_posts() ) :
+                while ( $planes_query->have_posts() ) : $planes_query->the_post();
+                    // Obtener campos personalizados (ejemplos, el JS se encargará de la lógica del toggle)
+                    $plan_id = get_the_ID();
+                    $titulo_plan = get_the_title();
+                    $precio_mensual = get_post_meta( $plan_id, 'plan_precio_mensual', true );
+                    $id_producto_mensual = get_post_meta( $plan_id, 'plan_id_producto_woo_mensual', true );
+                    $precio_anual = get_post_meta( $plan_id, 'plan_precio_anual', true );
+                    $id_producto_anual = get_post_meta( $plan_id, 'plan_id_producto_woo_anual', true );
+                    $texto_ahorro_anual = get_post_meta( $plan_id, 'plan_texto_ahorro_anual', true );
+                    $es_destacado = get_post_meta( $plan_id, 'plan_destacado', true ); // 'si' o 'no'
+                    $funcionalidades_raw = get_post_meta( $plan_id, 'plan_funcionalidades', true );
+                    $texto_boton = get_post_meta( $plan_id, 'plan_texto_boton', true ) ?: 'Suscribirme Ahora'; // Fallback
+
+                    $funcionalidades = explode("\n", $funcionalidades_raw); // Asume una funcionalidad por línea
+
+                    $checkout_url_base = home_url('/checkout/?add-to-cart=');
+
+                    $destacado_class = ($es_destacado === 'si') ? 'border-2 border-violetaNeon shadow-2xl shadow-violetaNeon/30 relative transform scale-105' : 'border border-gray-700/80';
+                    $destacado_badge = ($es_destacado === 'si') ? '<span class="absolute top-0 -translate-y-1/2 left-1/2 -translate-x-1/2 bg-gradient-to-r from-cianElectrico to-violetaNeon text-blancoPuro text-xs font-semibold px-4 py-1 rounded-full shadow-md">Más Popular</span>' : '';
+            ?>
+            <div class="pricing-plan-column flex flex-col bg-gray-800/30 backdrop-blur-md rounded-xl p-6 md:p-8 <?php echo esc_attr($destacado_class); ?>">
+                <?php echo $destacado_badge; ?>
+                <h3 class="font-sora text-2xl font-bold text-blancoPuro text-center mb-2"><?php echo esc_html($titulo_plan); ?></h3>
+
+                <div class="text-center mb-6 min-h-[80px]"> <?php // min-h para alinear botones si los precios/ahorro cambian altura ?>
+                    <span class="plan-price font-sora text-4xl md:text-5xl font-bold text-blancoPuro"
+                          data-precio-mensual="<?php echo esc_attr($precio_mensual); ?>"
+                          data-precio-anual="<?php echo esc_attr($precio_anual); ?>"
+                          data-texto-ahorro-anual="<?php echo esc_attr($texto_ahorro_anual); // Añadido esto ?>">
+                        $<?php echo esc_html(number_format((float)$precio_mensual, 0, ',', '.')); ?>
+                    </span>
+                    <span class="plan-period font-inter text-grisClaro text-sm">/mes</span>
+                    <p class="plan-ahorro-anual text-xs text-cianElectrico font-semibold mt-1 h-4">
+                        <?php // El JS llenará esto si es anual, ej: esc_html($texto_ahorro_anual) ?>
+                    </p>
+                </div>
+
+                <ul class="space-y-3 mb-8 flex-grow">
+                    <?php foreach ($funcionalidades as $funcionalidad) : if (trim($funcionalidad)) : ?>
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 text-cianElectrico mr-2 flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"></path></svg>
+                        <span class="font-inter text-sm text-grisClaro"><?php echo esc_html(trim($funcionalidad)); ?></span>
+                    </li>
+                    <?php endif; endforeach; ?>
+                </ul>
+
+                <a href="<?php echo esc_url($checkout_url_base . $id_producto_mensual); ?>"
+                   class="plan-cta-button mt-auto block w-full text-center font-inter text-blancoPuro text-base font-semibold px-8 py-3 rounded-lg
+                          bg-gradient-to-r from-cianElectrico to-violetaNeon
+                          hover:from-violetaNeon hover:to-cianElectrico
+                          transition-all duration-300 ease-in-out transform hover:scale-105"
+                   data-id-producto-mensual="<?php echo esc_attr($id_producto_mensual); ?>"
+                   data-id-producto-anual="<?php echo esc_attr($id_producto_anual); ?>">
+                    <?php echo esc_html($texto_boton); ?>
+                </a>
+            </div>
+            <?php
+                endwhile;
+                wp_reset_postdata(); // Importante después de un loop WP_Query personalizado
+            else :
+            ?>
+                <p class="text-center col-span-full text-grisClaro">No hay planes disponibles en este momento. Por favor, vuelve más tarde.</p>
+            <?php
+            endif;
+            ?>
+        </div> <!-- /#pricingPlansContainer -->
+
+    </div>
+</main>
+
+<?php
+get_footer();
+?>


### PR DESCRIPTION
He creado una página de precios completamente funcional y dinámica para el tema Jacobo, con las siguientes características:

1.  **Custom Post Type (CPT) "Planes":**
    *   Registré un CPT 'plan' para gestionar los planes de precios (Creador, Pro, Agencia) de forma estructurada.
    *   Soporte para título, editor (descripción), atributos de página (orden) y campos personalizados.
    *   Definí los campos personalizados necesarios: precios mensuales/anuales, IDs de productos de suscripción de WooCommerce (mensual/anual), texto de ahorro anual, plan destacado, lista de funcionalidades y texto del botón CTA.

2.  **Plantilla de Página "Precios" (`template-precios.php`):
    *   Nueva plantilla de página personalizada para mostrar los planes.
    *   Diseño visual coherente con la estética "Magia Tecnológica" (modo oscuro, gradientes, tipografía Sora/Inter).
    *   Incluye un título principal y un interruptor (toggle) para seleccionar entre precios mensuales y anuales.
    *   Utiliza `WP_Query` para obtener y mostrar los planes del CPT, ordenados según el campo "Orden".
    *   Cada plan se muestra en una tarjeta con: título, precio (dinámico según toggle), lista de funcionalidades con iconos de check, y un botón CTA.
    *   El plan marcado como "destacado" tiene un diseño visual especial (borde gradiente, insignia).
    *   Los datos relevantes (precios, IDs de producto) se almacenan en atributos `data-*` para la manipulación con JavaScript.

3.  **Integración con WooCommerce:**
    *   Los botones CTA en cada plan generan dinámicamente un enlace `add-to-cart` de WooCommerce.
    *   Estos enlaces añaden el producto de suscripción correcto (mensual o anual, según el toggle) al carrito y te redirigen a la página de checkout.
    *   La URL base para el checkout se pasa de forma segura a JavaScript usando `wp_localize_script`.

4.  **Interactividad JavaScript (`js/page-precios.js`):
    *   Nuevo archivo JavaScript encolado específicamente para la página de precios.
    *   Maneja el evento `change` del toggle mensual/anual.
    *   Actualiza dinámicamente en el DOM: el precio mostrado, el período (/mes o /año), el texto de ahorro anual y el `href` del botón CTA para cada plan.
    *   Incluye formateo básico de precios.

5.  **Guía para ti:**
    *   He definido las instrucciones para que crees los productos de suscripción en WooCommerce y completes los datos de cada plan en el CPT "Planes" a través de los campos personalizados.

Esta implementación proporciona una solución robusta y flexible para mostrar y vender los planes de suscripción de Jacobo.