### PR TITLE
feat(emails): Personalizar plantillas de email de WooCommerce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# WordPress
+wp-admin/
+wp-content/plugins/
+wp-content/themes/
+wp-includes/
+index.php
+license.txt
+readme.html
+wp-activate.php
+wp-blog-header.php
+wp-comments-post.php
+wp-config-sample.php
+wp-config.php
+wp-cron.php
+wp-links-opml.php
+wp-load.php
+wp-login.php
+wp-mail.php
+wp-settings.php
+wp-signup.php
+wp-trackback.php
+xmlrpc.php
+
+# WooCommerce
+wp-content/plugins/woocommerce/
+woocommerce.zip
+woocommerce_temp/
+
+# Exclude the theme I'm working on from being ignored
+!wp-content/themes/jacobo-theme/

--- a/jacobo-theme/woocommerce/emails/customer-completed-order.php
+++ b/jacobo-theme/woocommerce/emails/customer-completed-order.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Customer completed order email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-completed-order.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 9.9.0
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+ob_start(); // Jacobo: Start output buffering
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', '¡Tu pedido en Jacobo ha sido completado!', $email ); // Jacobo: Changed email heading
+?>
+
+<?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+<p>
+<?php
+if ( ! empty( $order->get_billing_first_name() ) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) );
+} else {
+	printf( esc_html__( 'Hi,', 'woocommerce' ) );
+}
+?>
+</p>
+<p><?php esc_html_e( '¡Buenas noticias! Hemos procesado y completado tu pedido en Jacobo. A continuación encontrarás los detalles.', 'woocommerce' ); // Jacobo: Customized main text ?></p>
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<style type="text/css">
+	table, th, td {
+		border-color: #334155 !important; /* Jacobo: Ensure borders are visible on dark background */
+		color: #E0E0E0 !important; /* Jacobo: Ensure text is legible on dark background */
+	}
+	th {
+		background-color: #1E293B !important; /* Jacobo: Darker background for headers for contrast */
+	}
+	td a, p a {
+		color: #7DD3FC !important; /* Jacobo: Light blue for links, matching common dark theme palettes */
+	}
+</style>
+
+<?php
+
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );
+
+<?php $content = ob_get_clean(); echo jacobo_get_email_template_html( '¡Tu pedido en Jacobo ha sido completado!', $content ); // Jacobo: End output buffering and pass to template ?>

--- a/jacobo-theme/woocommerce/emails/customer-invoice.php
+++ b/jacobo-theme/woocommerce/emails/customer-invoice.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Customer invoice email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-invoice.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 9.8.0
+ */
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+ob_start(); // Jacobo: Start output buffering
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/**
+ * Executes the e-mail header.
+ *
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', 'Factura de tu pedido en Jacobo / Detalles del Pedido', $email ); // Jacobo: Changed email heading
+?>
+
+<?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+<p>
+<?php
+if ( ! empty( $order->get_billing_first_name() ) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) );
+} else {
+	printf( esc_html__( 'Hi,', 'woocommerce' ) );
+}
+?>
+</p>
+<?php if ( $order->needs_payment() ) { ?>
+	<p>
+	<?php
+	// Jacobo: Kept original logic for orders needing payment, but could be customized if needed.
+	if ( $order->has_status( OrderStatus::FAILED ) ) {
+		printf(
+			wp_kses(
+			/* translators: %1$s Site title, %2$s Order pay link */
+				__( 'Sorry, your order on %1$s was unsuccessful. Your order details are below, with a link to try your payment again: %2$s', 'woocommerce' ),
+				array(
+					'a' => array(
+						'href' => array(),
+					),
+				)
+			),
+			esc_html( get_bloginfo( 'name', 'display' ) ),
+			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
+		);
+	} else {
+		printf(
+			wp_kses(
+			/* translators: %1$s Site title, %2$s Order pay link */
+				__( 'An order has been created for you on %1$s. Your order details are below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
+				array(
+					'a' => array(
+						'href' => array(),
+					),
+				)
+			),
+			esc_html( get_bloginfo( 'name', 'display' ) ),
+			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
+		);
+	}
+	?>
+	</p>
+
+<?php } else { ?>
+	<p>
+	<?php
+	// Jacobo: Customized invoice text
+	/* translators: %s: Order number */
+	printf( esc_html__( 'Adjuntamos los detalles de tu factura para el pedido %s. Estamos aquí para cualquier consulta.', 'woocommerce' ), esc_html( $order->get_order_number() ) );
+	?>
+	</p>
+	<?php
+}
+?>
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<style type="text/css">
+	table, th, td {
+		border-color: #334155 !important; /* Jacobo: Ensure borders are visible on dark background */
+		color: #E0E0E0 !important; /* Jacobo: Ensure text is legible on dark background */
+	}
+	th {
+		background-color: #1E293B !important; /* Jacobo: Darker background for headers for contrast */
+	}
+	td a, p a {
+		color: #7DD3FC !important; /* Jacobo: Light blue for links, matching common dark theme palettes */
+	}
+</style>
+
+<?php
+
+/**
+ * Hook for the woocommerce_email_order_details.
+ *
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Hook for the woocommerce_email_order_meta.
+ *
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Hook for woocommerce_email_customer_details.
+ *
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/**
+ * Executes the email footer.
+ *
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );
+
+<?php $content = ob_get_clean(); echo jacobo_get_email_template_html( 'Factura de tu pedido en Jacobo / Detalles del Pedido', $content ); // Jacobo: End output buffering and pass to template ?>

--- a/jacobo-theme/woocommerce/emails/customer-processing-order.php
+++ b/jacobo-theme/woocommerce/emails/customer-processing-order.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Customer processing order email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-processing-order.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 9.9.0
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+ob_start(); // Jacobo: Start output buffering
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', '¡Bienvenido a la Revolución del Marketing con IA!', $email ); // Jacobo: Replaced email heading
+?>
+
+<?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
+<p>
+<?php
+// Jacobo: Customized welcome message
+if ( ! empty( $order->get_billing_first_name() ) ) {
+	printf(
+		// translators: %1$s: Customer first name.
+		esc_html__( 'Hola %1$s, ¡estamos increíblemente felices de tenerte a bordo! Tu nueva suscripción está activa. Ya puedes iniciar sesión en tu dashboard y empezar a crear campañas inteligentes. Si tienes alguna pregunta, nuestro equipo está aquí para ayudarte. ¡Vamos a crear algo legendario!', 'woocommerce' ),
+		esc_html( $order->get_billing_first_name() )
+	);
+} else {
+	esc_html_e( 'Hola, ¡estamos increíblemente felices de tenerte a bordo! Tu nueva suscripción está activa. Ya puedes iniciar sesión en tu dashboard y empezar a crear campañas inteligentes. Si tienes alguna pregunta, nuestro equipo está aquí para ayudarte. ¡Vamos a crear algo legendario!', 'woocommerce' );
+}
+?>
+</p>
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<style type="text/css">
+	table, th, td {
+		border-color: #334155 !important; /* Jacobo: Ensure borders are visible on dark background */
+		color: #E0E0E0 !important; /* Jacobo: Ensure text is legible on dark background */
+	}
+	th {
+		background-color: #1E293B !important; /* Jacobo: Darker background for headers for contrast */
+	}
+	td a, p a {
+		color: #7DD3FC !important; /* Jacobo: Light blue for links, matching common dark theme palettes */
+	}
+</style>
+
+<?php
+
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );
+
+<?php $content = ob_get_clean(); echo jacobo_get_email_template_html( '¡Bienvenido a Jacobo!', $content ); // Jacobo: End output buffering and pass to template ?>

--- a/woocommerce.latest.zip
+++ b/woocommerce.latest.zip
@@ -1,0 +1,1 @@
+Not found


### PR DESCRIPTION
He modificado las siguientes plantillas de email de WooCommerce para alinearlas con la identidad visual "Magia Tecnológica" y el tono de voz de "Jacobo":

- customer-processing-order.php
- customer-completed-order.php
- customer-invoice.php

Principales cambios:
- Integración de la plantilla HTML base `jacobo_get_email_template_html()` para un diseño coherente.
- Personalización de los encabezados y el cuerpo de los mensajes para reflejar la marca "Jacobo".
    - El email "customer-processing-order" ahora sirve como una bienvenida más cálida para nuevas suscripciones.
- Adición de estilos CSS (mediante un bloque `<style>`) para asegurar la legibilidad del contenido y las tablas de detalles del pedido sobre un fondo oscuro.
- Creación de la estructura de carpetas `jacobo-theme/woocommerce/emails/` para la sobreescritura de plantillas.

Estos cambios aseguran que la comunicación por correo electrónico de WooCommerce sea consistente con la experiencia general de la plataforma Jacobo.