### PR TITLE
fix: Implementar inicio de sesión manual en página de agradecimiento

### DIFF
--- a/jacobo-theme/functions.php
+++ b/jacobo-theme/functions.php
@@ -912,24 +912,35 @@ add_action( 'woocommerce_order_status_changed', 'jacobo_update_user_role_on_orde
 */
 
 /**
- * Redirige a los usuarios al dashboard principal después de una compra.
+ * Redirige a los usuarios al dashboard principal después de una compra
+ * e inicia sesión manualmente al usuario.
  */
 function jacobo_custom_thankyou_redirect( $order_id ){
-    // URL de nuestro dashboard principal.
-    // Asegúrate de que el slug '/dashboard-principal/' sea correcto.
     $dashboard_url = home_url('/dashboard-principal/');
     if ( ! $order_id ){
         return;
     }
-    // Comprobar si el pedido existe y es válido
-    $order = wc_get_order( $order_id );
+
+    $order = wc_get_order($order_id);
+    // Salir si no se puede obtener el objeto de pedido
     if ( ! $order ) {
         return;
     }
+
+    $user_id = $order->get_user_id();
+
+    // Iniciar sesión al usuario manualmente si hay un user_id válido y el usuario no está ya logueado.
+    if ( $user_id && $user_id > 0 ) {
+        if ( !is_user_logged_in() ) {
+             wp_set_current_user($user_id);
+             wp_set_auth_cookie($user_id, true); // true para 'remember me'
+        }
+    }
+
     wp_safe_redirect( $dashboard_url );
     exit;
 }
-add_action( 'woocommerce_thankyou', 'jacobo_custom_thankyou_redirect' );
+add_action( 'woocommerce_thankyou', 'jacobo_custom_thankyou_redirect', 10, 1 );
 
 // --- INICIO BLOQUE DE CÓDIGO CONSOLIDADO ---
 


### PR DESCRIPTION
He modificado la función `jacobo_custom_thankyou_redirect` en `functions.php` para iniciar sesión manualmente después de un pago exitoso.

Anteriormente, el filtro `woocommerce_registration_auth_new_user` prevenía el auto-login durante el registro en el checkout. Para asegurar que tengas la sesión iniciada después de un pago exitoso y antes de ser redirigido al dashboard, esta función ahora:
1. Obtiene tu ID a partir del ID del pedido.
2. Utiliza `wp_set_current_user()` y `wp_set_auth_cookie()` para establecer tu sesión.
3. Te redirige (ya con sesión iniciada) a la página `/dashboard-principal/`.

He verificado también que el `add_action` para `woocommerce_thankyou` tenga la prioridad (10) y el número de argumentos (1) correctos.

Este cambio completa la lógica deseada para el flujo de registro y post-compra, asegurando que accedas directamente a tu dashboard con la sesión iniciada después de un pago exitoso, mientras se previene el auto-login prematuro durante el checkout. Las demás funciones de la lógica definitiva de roles y emails permanecen sin cambios.