### PR TITLE
refactor: Simplificar control de email de bienvenida (v7)

### DIFF
--- a/jacobo-theme/functions.php
+++ b/jacobo-theme/functions.php
@@ -950,22 +950,6 @@ add_action( 'woocommerce_thankyou', 'jacobo_custom_thankyou_redirect', 10, 1 );
 add_filter( 'woocommerce_registration_auth_new_user', '__return_false' );
 
 /**
- * TAREA REVISADA: Desactiva el email de bienvenida estándar de WooCommerce durante el checkout.
- * Esto previene que se envíe un correo antes de confirmar el pago.
- * Simplificado para ser más directo.
- */
-function jacobo_disable_new_account_email_on_checkout( $enabled, $user = null ) {
-    if ( is_checkout() ) {
-        // Deshabilitar el email de nueva cuenta si estamos en el proceso de checkout.
-        // Nuestra otra función jacobo_assign_role_and_send_welcome_email lo enviará
-        // SOLO cuando la suscripción YITH se active con éxito.
-        return false;
-    }
-    return $enabled;
-}
-add_filter( 'woocommerce_email_enabled_new_account', 'jacobo_disable_new_account_email_on_checkout', 999, 2 );
-
-/**
  * TAREA 3: Asigna el rol 'cliente_jacobo' y envía el email de bienvenida
  * SÓLO cuando una suscripción de YITH se activa con éxito.
  */


### PR DESCRIPTION
He refactorizado `functions.php` para simplificar el control del email de bienvenida de WooCommerce ("Nueva cuenta"). La estrategia ahora se basa en que este email esté deshabilitado globalmente en los ajustes de WooCommerce, y lo envío manualmente solo cuando es necesario.

Cambios Clave en esta iteración (v7):
1.  **Eliminación de Filtro Condicional de Email:**
    - Eliminé la función `jacobo_disable_new_account_email_on_checkout` (y sus variantes previas) junto con su filtro asociado a `woocommerce_email_enabled_new_account`. Estos intentos de deshabilitar condicionalmente el email no fueron consistentemente efectivos.

2.  **Envío Manual de Email de Bienvenida Centralizado:**
    - La función `jacobo_assign_role_and_send_welcome_email` (que se ejecuta tras la activación de una suscripción YITH) sigue siendo la única responsable de enviar el email de bienvenida de WooCommerce (`WC_Email_Customer_New_Account`) utilizando el método `trigger()`. Este método envía el email incluso si está deshabilitado en los ajustes globales de WooCommerce.

3.  **Lógica de Roles y Gestión de Usuarios (v6) Mantenida:**
    - Conservé las funciones implementadas en la v6 para: - Prevención de auto-login en el registro (`woocommerce_registration_auth_new_user`). - Asignación del rol 'cliente_jacobo' (parte de `jacobo_assign_role_and_send_welcome_email`). - Eliminación segura de usuarios con rol 'customer' en caso de primer pedido fallido, verificando otros pedidos/suscripciones (`jacobo_delete_user_on_failed_order`). - Redirección post-compra con inicio de sesión manual (`jacobo_custom_thankyou_redirect`). - Ocultación de la pestaña "Descargas" (`jacobo_remove_my_account_downloads_tab`).

Este enfoque requiere que el email "Nueva cuenta" esté deshabilitado manualmente en WooCommerce > Ajustes > Correos electrónicos para prevenir envíos automáticos no deseados.